### PR TITLE
Add a time output option to bistre.

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -2,8 +2,11 @@
 
 var bistre = require('./')
 
+var opts = {}
+opts.time = (process.argv.indexOf('--time') > -1)
+
 process.stdin.resume()
 process.stdin.setEncoding('utf8')
 process.stdin
-  .pipe(bistre())
+  .pipe(bistre(opts))
   .pipe(process.stdout)

--- a/index.js
+++ b/index.js
@@ -23,7 +23,11 @@ var levels = {
   , info: 'blue'
 }
 
-function bistre() {
+function bistre(opts) {
+
+  opts = opts || {}
+  var showTime = !!opts.time
+
   return combiner(split()
     , through2.obj(write)
   )
@@ -45,6 +49,9 @@ function bistre() {
       poolIndex[name] = pool[poolCount++ % pool.length]
     )
 
+    if (showTime) {
+      line.push(chalk.gray(data.time))
+    }
     line.push(chalk[level](pad(data.level, 5)))
     line.push(chalk[nameColor](data.name + ':'))
 

--- a/package.json
+++ b/package.json
@@ -11,10 +11,10 @@
   "author": "Hugh Kennedy <hughskennedy@gmail.com> (http://hughsk.io/)",
   "license": "MIT",
   "dependencies": {
-    "chalk": "^0.4.0",
+    "chalk": "^0.5.1",
     "split": "^0.3.0",
     "stream-combiner": "^0.2.0",
-    "through2": "^0.4.1"
+    "through2": "^0.5.1"
   },
   "devDependencies": {
     "bole": "^0.1.0"

--- a/test.js
+++ b/test.js
@@ -1,7 +1,8 @@
-var bistre = require('./')()
+var bistre = require('./')
 var bole = require('bole')
 
-bistre.pipe(process.stdout)
+var b1 = bistre()
+b1.pipe(process.stdout)
 
 var logs = [
   bole('first')
@@ -15,7 +16,7 @@ var logs = [
 
 bole.output({
     level: 'debug'
-  , stream: bistre
+  , stream: b1
 })
 
 logs.forEach(function(log) {
@@ -31,3 +32,14 @@ logs.forEach(function(log) {
   log.debug('hello world')
 })
 logs[0].debug(new Error('hello world'))
+
+var b2 = bistre({ time: true })
+bole.output({
+    level: 'debug'
+  , stream: b2
+})
+b2.pipe(process.stdout)
+
+logs.forEach(function(log) {
+  log.info('the world is on time')
+})


### PR DESCRIPTION
This is the only bistre output feature I have been missing, so I figured I'd add it!

Pass --time to bistre to see a logline's timestamp in gray.
Passing no option retains the current behavior.

Added an output test for it in the same mode as the existing tests.
While I was there, bumped the versions for the chalk & through deps.
