### PR TITLE
A bug fix & an optimization

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,10 +32,16 @@ function bistre(opts) {
     , through2.obj(write)
   )
 
-  function write(data, _, next) {
+  function safeparse(data) {
     try {
       data = JSON.parse(data)
-    } catch(e) {
+    } catch(e) { }
+    return data
+  }
+
+  function write(data, _, next) {
+    data = safeparse(data)
+    if (typeof data !== 'object') {
       this.push(data)
       this.push('\n')
       return next()
@@ -43,7 +49,7 @@ function bistre(opts) {
 
     var level = levels[data.level] || 'yellow'
     var line = []
-    var name = data.name.replace(/\:[-:a-z0-9]{8,}$/g, '')
+    var name = data.name ? data.name.replace(/\:[-:a-z0-9]{8,}$/g, '') : ''
 
     var nameColor = poolIndex[name] || (
       poolIndex[name] = pool[poolCount++ % pool.length]


### PR DESCRIPTION
- Move the try/catch around the JSON.parse() into a separate function so the main one can be optimized.
- Check for an object result, not just a failure in the parse.This handles the case where bistre is handling all output from a process and you do something like `console.log(3)`. The bare number is valid JSON, but not a structured json log line.
- Check for the existence of the name property before trying  to call .replace() on it. Revealed by the previous case, though not strictly necessary now that we short-circuit. Still, this is safer, just in case bistre ever gets valid json without that field piped through it.

Sorry about two PRs in short order! I tripped over this immediately after you landed the previous one.
